### PR TITLE
Change protocol to https to fix SPOJ solutions' fetch failure

### DIFF
--- a/src/com/koldbyte/codebackup/core/TestApp.java
+++ b/src/com/koldbyte/codebackup/core/TestApp.java
@@ -114,12 +114,12 @@ public class TestApp {
 	}
 
 	public static void test8() {
-		Problem problem = new SpojProblem("http://www.spoj.com/problems/FCTRL/");
+		Problem problem = new SpojProblem("https://www.spoj.com/problems/FCTRL/");
 		System.out.println(problem.getProblemStatement());
 	}
 
 	public static void test9() {
-		User u = new SpojUser("koldbyte", "http://www.spoj.com/users/koldbyte/");
+		User u = new SpojUser("koldbyte", "https://www.spoj.com/users/koldbyte/");
 		PluginInterface plugin = new SpojPluginImpl();
 		List<Submission> list = plugin.getSolvedList(u);
 		for (Submission s : list) {
@@ -131,8 +131,8 @@ public class TestApp {
 	}
 
 	public static void test10() {
-		User u = new SpojUser("koldbyte", "http://www.spoj.com/users/koldbyte/");
-		Problem p = new SpojProblem("http://www.spoj.com/problems/BITMAP/");
+		User u = new SpojUser("koldbyte", "https://www.spoj.com/users/koldbyte/");
+		Problem p = new SpojProblem("https://www.spoj.com/problems/BITMAP/");
 		((SpojUser) u).setUsername("koldbyte");
 		((SpojUser) u).setPass("thisisrandompass");
 		Submission s = new SpojSubmission("11808446",

--- a/src/com/koldbyte/codebackup/plugins/spoj/SpojPluginImpl.java
+++ b/src/com/koldbyte/codebackup/plugins/spoj/SpojPluginImpl.java
@@ -19,15 +19,15 @@ import com.koldbyte.codebackup.plugins.spoj.core.entities.SpojUser;
 
 public class SpojPluginImpl implements PluginInterface {
 
-	private final String HTTP = "http://";
+	private final String HTTPS = "https://";
 	private final String SUBMISSIONLIST = "www.spoj.com/status/:u/signedlist/";
 
-	private final String LOGINURL = "http://www.spoj.com/login";
+	private final String LOGINURL = HTTPS + "www.spoj.com/login";
 	
 	@Override
 	public List<Submission> getSolvedList(User user) {
 		List<Submission> subs = new ArrayList<Submission>();
-		String url = HTTP + SUBMISSIONLIST.replace(":u", user.getHandle());
+		String url = HTTPS + SUBMISSIONLIST.replace(":u", user.getHandle());
 
 		try {
 			//TODO: Add login to fetch the spoj signedlist
@@ -100,7 +100,7 @@ public class SpojPluginImpl implements PluginInterface {
 	@Override
 	public List<Submission> getAllSolvedList(User user) {
 		List<Submission> subs = new ArrayList<Submission>();
-		String url = HTTP + SUBMISSIONLIST.replace(":u", user.getHandle());
+		String url = HTTPS + SUBMISSIONLIST.replace(":u", user.getHandle());
 
 		try {
 			//TODO: Add login to fetch the spoj signedlist

--- a/src/com/koldbyte/codebackup/plugins/spoj/core/entities/SpojProblem.java
+++ b/src/com/koldbyte/codebackup/plugins/spoj/core/entities/SpojProblem.java
@@ -10,13 +10,13 @@ import org.jsoup.nodes.Entities.EscapeMode;
 import com.koldbyte.codebackup.core.entities.Problem;
 
 public class SpojProblem extends Problem {
-	private final String HTTP = "http://";
+	private final String HTTPS = "https://";
 	private final String PROBLEMURL = "www.spoj.com/problems/:p/";
 
 	@Override
 	public String fetchProblemStatement() {
 		String problem = getProblemId();
-		String url = HTTP + PROBLEMURL.replace(":p", problem);
+		String url = HTTPS + PROBLEMURL.replace(":p", problem);
 		/*-
 		 * Spoj Problem Page looks like this 
 		 * 
@@ -56,7 +56,7 @@ public class SpojProblem extends Problem {
 			// replace ":p" with the problem id
 			problemUrl.replace(":p", problemId);
 
-			url = HTTP + PROBLEMURL;
+			url = HTTPS + PROBLEMURL;
 			this.setUrl(url);
 		}
 		return url;
@@ -66,7 +66,7 @@ public class SpojProblem extends Problem {
 	public String getProblemId() {
 		if (problemId == null || problemId.isEmpty()) {
 			String u = getUrl();
-			u = u.replace(HTTP, "");
+			u = u.replace(HTTPS, "");
 			u = u.replace("www.spoj.com/problems/", "");
 			u = u.replace("/", "");
 			this.setProblemId(u);

--- a/src/com/koldbyte/codebackup/plugins/spoj/core/entities/SpojSubmission.java
+++ b/src/com/koldbyte/codebackup/plugins/spoj/core/entities/SpojSubmission.java
@@ -10,9 +10,9 @@ import com.koldbyte.codebackup.core.entities.Submission;
 import com.koldbyte.codebackup.core.entities.User;
 
 public class SpojSubmission extends Submission {
-	private final String HTTP = "http://";
+	private final String HTTPS = "https://";
 	private final String SUBMITTEDURL = "www.spoj.com/files/src/save/:s/";
-	private final String LOGINURL = "http://www.spoj.com/login";
+	private final String LOGINURL = HTTPS + "www.spoj.com/login";
 
 	@Override
 	public String fetchSubmittedCode() {
@@ -34,7 +34,7 @@ public class SpojSubmission extends Submission {
 					.method(Connection.Method.POST).execute();
 
 			// login done...now use the cookies to whenever u are fetching code
-			String url = HTTP + SUBMITTEDURL.replace(":s", submissionId);
+			String url = HTTPS + SUBMITTEDURL.replace(":s", submissionId);
 			String code = Jsoup.connect(url).ignoreContentType(true)
 					.cookies(loginForm.cookies()).method(Connection.Method.GET)
 					.execute().body();
@@ -57,7 +57,7 @@ public class SpojSubmission extends Submission {
 	@Override
 	public String getSubmissionIdFromUrl() {
 		String url = getSubmissionUrl();
-		url = url.replace(HTTP, "");
+		url = url.replace(HTTPS, "");
 		url = url.replace("www.spoj.com/files/src/save/", "");
 		url = url.replace("/", "");
 		return url;
@@ -65,7 +65,7 @@ public class SpojSubmission extends Submission {
 
 	@Override
 	public String getSubmissionUrlFromId() {
-		String subId = HTTP + SUBMITTEDURL.replace(":s", getSubmissionId());
+		String subId = HTTPS + SUBMITTEDURL.replace(":s", getSubmissionId());
 		return subId;
 	}
 

--- a/src/com/koldbyte/codebackup/plugins/spoj/core/entities/SpojUser.java
+++ b/src/com/koldbyte/codebackup/plugins/spoj/core/entities/SpojUser.java
@@ -3,7 +3,7 @@ package com.koldbyte.codebackup.plugins.spoj.core.entities;
 import com.koldbyte.codebackup.core.entities.User;
 
 public class SpojUser extends User {
-	private final String HTTP = "http://";
+	private final String HTTPS = "https://";
 	private final String PROFILEURL = "www.spoj.com/users/:u/";
 
 	private String username;
@@ -36,7 +36,7 @@ public class SpojUser extends User {
 	@Override
 	public String getHandleFromProfileUrl() {
 		String handle = profileUrl;
-		handle = handle.replace(HTTP, "");
+		handle = handle.replace(HTTPS, "");
 		handle = handle.replace("www.spoj.com/users/", "");
 		handle = handle.replace("/", "");
 		return handle;
@@ -44,7 +44,7 @@ public class SpojUser extends User {
 
 	@Override
 	public String getProfileUrlFromHandle() {
-		return HTTP + PROFILEURL.replace(":u", this.handle);
+		return HTTPS + PROFILEURL.replace(":u", this.handle);
 	}
 
 	@Override


### PR DESCRIPTION
Change in this revision
- Change protocol from http to https for the SPOJ endpoints

Previously the following error was showing up:
**Error! Invalid format of Spoj signed list** and an empty list of solutions was being fetched

Screenshot for reference:
<img width="343" alt="screen shot 2019-01-08 at 5 50 57 am" src="https://user-images.githubusercontent.com/6589094/50801169-9364c900-1309-11e9-8090-8ae223f211a4.png">


After the change in the diff:
<img width="350" alt="screen shot 2019-01-08 at 5 57 27 am" src="https://user-images.githubusercontent.com/6589094/50801388-741a6b80-130a-11e9-812d-8bb51e99c64e.png">

<img width="264" alt="screen shot 2019-01-08 at 5 28 09 am" src="https://user-images.githubusercontent.com/6589094/50801191-b1322e00-1309-11e9-8d4d-a8fa6466b411.png">

